### PR TITLE
Add makeFilter tests, DRY listScripts, & fix commit history

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -30,12 +30,10 @@ type filterTuple struct {
 func listScripts() ([]string, error) {
 	var results []string
 
-	myuser, err := user.Current()
+	path, err := getCachePath("")
 	if err != nil {
 		return nil, err
 	}
-	pathParts := []string{myuser.HomeDir, ".iopipe", "filter_cache"}
-	path := path.Join(pathParts...)
 	fi, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -313,18 +311,17 @@ func createPipeline(pipeparts []string) (string, error) {
 	return "", nil
 }
 
-func removeFilter(filterid string) (error) {
-        path, err := getCachePath(filterid)
-        if err != nil {
-                return err
-        }
-        err = os.Remove(path)
-        if err != nil {
-                return err
-        }
-        return nil
+func removeFilter(filterid string) error {
+	path, err := getCachePath(filterid)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(path)
+	if err != nil {
+		return err
+	}
+	return nil
 }
-
 
 func tagPipeline(pipeline string) error {
 	return nil

--- a/filter.go
+++ b/filter.go
@@ -30,10 +30,12 @@ type filterTuple struct {
 func listScripts() ([]string, error) {
 	var results []string
 
-	path, err := getCachePath("")
+	myuser, err := user.Current()
 	if err != nil {
 		return nil, err
 	}
+	pathParts := []string{myuser.HomeDir, ".iopipe", "filter_cache"}
+	path := path.Join(pathParts...)
 	fi, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
@@ -311,17 +313,18 @@ func createPipeline(pipeparts []string) (string, error) {
 	return "", nil
 }
 
-func removeFilter(filterid string) error {
-	path, err := getCachePath(filterid)
-	if err != nil {
-		return err
-	}
-	err = os.Remove(path)
-	if err != nil {
-		return err
-	}
-	return nil
+func removeFilter(filterid string) (error) {
+        path, err := getCachePath(filterid)
+        if err != nil {
+                return err
+        }
+        err = os.Remove(path)
+        if err != nil {
+                return err
+        }
+        return nil
 }
+
 
 func tagPipeline(pipeline string) error {
 	return nil

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+        "testing"
+)
+
+func TestMakeRunFilter(t *testing.T) {
+        //script string) (func(input string) (string, error), error) {
+        fun, err := makeFilter("\"hello\"")
+        if err != nil {
+                t.Error(err)
+        }
+        result, err := fun("")
+        if result != "hello" {
+                t.Error("You should have had me at hello")
+        }
+}
+
+func TestMakeRunEchoFilter(t *testing.T) {
+        //script string) (func(input string) (string, error), error) {
+        fun, err := makeFilter("input")
+        if err != nil {
+                t.Error(err)
+        }
+        result, err := fun("echo")
+        if result != "echo" {
+                t.Error("Filter did not echo input.")
+        }
+}
+
+func TestMakeRunFailsInvalidJSFilter(t *testing.T) {
+        /* Note: this is not valid ECMAScript */
+        fun, err := makeFilter("(╯°□°）╯︵ ┻━┻")
+        _, err = fun("")
+        if err == nil {
+                t.Error("One should not (╯°□°）╯︵ ┻━┻")
+        }
+}


### PR DESCRIPTION
The last makeFilter tests PR incorrectly solved a DRY problem in listScripts rather than adding the relevant tests. This adds the tests and fixes the commit history.
