### PR TITLE
Require pipescripts to use CommonJS format

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ upon locally in the client, whereas web-service based filters operate
 server-side. Pipescript may also be used to build serverside filters
 and applications.
 
-For writing filters see:
+Example:
+
+```javascript
+export.module = function(input) {
+  return "I'm doing something with input: {0}".format(input)
+}
+```
+
+For more on writing filters see:
 ***https://github.com/iopipe/iopipe/blob/master/docs/pipescript.md***
 
 ---------------------------------------

--- a/api.go
+++ b/api.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+
+	"fmt"
+	"os"
+
+	"io/ioutil"
+	"net/url"
+)
+
+func Exec(args ...string) (string, error) {
+	//var err error
+	var lastObj string
+	var msg string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		path, err := url.Parse(arg)
+		if err != nil {
+			return "", err
+		}
+
+		logrus.Info("pipe[arg]: " + arg)
+
+		if path.Scheme == "http" || path.Scheme == "https" {
+			argPath, err := dereferencePath(arg)
+			if err != nil {
+				return "", err
+			}
+			argObj := dereferenceObj(argPath)
+
+			// If first argument, then we must GET,
+			// note that this case follows the '-' so all
+			// shell input will pipe into the POST.
+			if i == 0 {
+				msg = argObj.read()
+			} else {
+				msg = argObj.update(lastObj)
+			}
+		} else if arg == "-" {
+			script, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return "", err
+			}
+			if i == 0 {
+				// If first argument, assume is generic bytes input.
+				msg = string(script[:])
+			} else {
+				// If not the first argument, then expect pipescript
+				filter, err := makeFilter(string(script[:]))
+				if err != nil {
+					return "", err
+				}
+				if msg, err = filter(lastObj); err != nil {
+					return "", err
+				}
+			}
+		} else {
+			filter, err := getFilter(arg)
+			if err != nil {
+				return "", err
+			}
+			// Search
+			if i == 0 {
+				msg, err = filter("")
+			} else {
+				msg, err = filter(lastObj)
+			}
+			if err != nil {
+				return "", err
+			}
+		}
+		logrus.Debug(fmt.Sprintf("pipe[%i][raw]: %s\n", i, msg))
+
+		lastObj = msg
+	}
+	return msg, nil
+}

--- a/cli.go
+++ b/cli.go
@@ -4,14 +4,11 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 
-	"fmt"
 	"log"
 	"os"
 	"path"
 
 	"encoding/json"
-	"io/ioutil"
-	"net/url"
 )
 
 var debug bool = false
@@ -231,84 +228,14 @@ func execFilter(lastObj string, toObjType string) (msg string, err error) {
 
 // Handle the 'exec' CLI command.
 func cmdExec(c *cli.Context) {
+	var msg string
+	var err error
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-
-	//var err error
-	var lastObj string
-
-	for i := 0; i < len(c.Args()); i++ {
-		arg := c.Args()[i]
-		var msg string
-
-		path, err := url.Parse(arg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		logrus.Info("pipe[arg]: " + arg)
-
-		if path.Scheme == "http" || path.Scheme == "https" {
-			argPath, err := dereferencePath(arg)
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-			argObj := dereferenceObj(argPath)
-
-			// If first argument, then we must GET,
-			// note that this case follows the '-' so all
-			// shell input will pipe into the POST.
-			if i == 0 {
-				msg = argObj.read()
-			} else {
-				msg = argObj.update(lastObj)
-			}
-		} else if arg == "-" {
-			script, err := ioutil.ReadAll(os.Stdin)
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-			if i == 0 {
-				// If first argument, assume is generic bytes input.
-				msg = string(script[:])
-			} else {
-				// If not the first argument, then expect pipescript
-				filter, err := makeFilter(string(script[:]))
-				if err != nil {
-					log.Fatal(err)
-					return
-				}
-				if msg, err = filter(lastObj); err != nil {
-					log.Fatal(err)
-					return
-				}
-			}
-		} else {
-			filter, err := getFilter(arg)
-			if err != nil {
-				log.Fatal("Filter not found.")
-				return
-			}
-			// Search
-			if i == 0 {
-				msg, err = filter("")
-			} else {
-				msg, err = filter(lastObj)
-			}
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-		}
-		logrus.Debug(fmt.Sprintf("pipe[%i][raw]: %s\n", i, msg))
-
-		if i == len(c.Args())-1 {
-			println(msg)
-			return
-		}
-		lastObj = msg
+	if msg, err = Exec(c.Args()...); err != nil {
+		log.Fatal(err)
+		return
 	}
+	println(msg)
 }

--- a/docs/pipescript.md
+++ b/docs/pipescript.md
@@ -1,19 +1,25 @@
 Pipescript is a subset of ECMAScript / Javascript.
 
-Scripts initiate with a variable predefined, 'input',
-containing input bytes to be parsed. Each script is associated
-with a pre-defined input and output type.
+Scripts are written in CommonJS module format in that they expect
+a function defined as 'module.exports'. This function should return
+a result intended for the next pipescript, function, or HTTP endpoint.
+
+Currently, a single argument and single string-type return variable
+are supported.
 
 ------------------
 Example pipescript
 ------------------
 
-The following converts a GenericMessage into a Twitter status update request:
+The following converts a JSON document representing a "GenericMessage"
+into a Twitter status update request (as expected by the Twitter API).
 
 ```javascript
-var obj = JSON.parse(input);
-var statusRequest = {
-  "status": obj["properties"]["text"]
-};
-JSON.stringify(statusRequest);
+module.exports = function(input) {
+  var obj = JSON.parse(input)
+  var statusRequest = {
+    "status": obj["properties"]["text"]
+  }
+  return JSON.stringify(statusRequest)
+}
 ```

--- a/filter.go
+++ b/filter.go
@@ -101,9 +101,19 @@ func makeFilter(script string) (func(input string) (string, error), error) {
 		logrus.Debug("Adding RequireJS")
 		vm.Run(rjs)
 
-		vm.Set("input", input)
 		logrus.Debug("Executing script: " + script)
-		val, err := vm.Run(script)
+                _, err := vm.Run(`
+                        var module = { "exports": function() { } }
+                `)
+                if err != nil {
+                        return "", err
+                }
+		_, err = vm.Run(script)
+		if err != nil {
+			return "", err
+		}
+		vm.Set("input", input)
+                val, err := vm.Run("module.exports(input)")
 		if err != nil {
 			return "", err
 		}

--- a/filter_test.go
+++ b/filter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMakeRunFilter(t *testing.T) {
-	fun, err := makeFilter("\"hello\"")
+	fun, err := makeFilter("module.exports = function(x) { return \"hello\" }")
 	if err != nil {
 		t.Error(err)
 	}
@@ -16,7 +16,7 @@ func TestMakeRunFilter(t *testing.T) {
 }
 
 func TestMakeRunEchoFilter(t *testing.T) {
-	fun, err := makeFilter("input")
+	fun, err := makeFilter("module.exports = function(input) { return input }")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Implement a CommonJS compatible format for pipescripts,
allowing them to be imported and used directly via NodeJS.

Simply define module.export as a function which receives
input from the previous function. Example:

``` javascript
    module.exports = function(input) {
      var data = JSON.decode(input)
      return data['extract_this_field']
    }
```
