### PR TITLE
NodeSDK improvements: convenience methods, bugfixes

### DIFF
--- a/js/iopipe.js
+++ b/js/iopipe.js
@@ -68,7 +68,7 @@ function pipescriptCallback(id, done) {
 exports.define = function() {
   var callbackList = []
   var nextCallback;
-  var done = function(result) { console.log(result) };
+  var done = function(result) { };
 
   for (var i = arguments.length - 1; i > -1; i--) {
     var arg = arguments[i];

--- a/js/iopipe.js
+++ b/js/iopipe.js
@@ -94,5 +94,28 @@ exports.define = function() {
 
 exports.exec = function() {
   var l = [].slice.call(arguments)
-  exports.define.apply(this, l)()
+  return exports.define.apply(this, l)()
+}
+
+exports.property = function (index) {
+  return function (obj) {
+    return obj[index]
+  }
+}
+
+exports.bind = function (method, arg) {
+  return function (obj) {
+    return obj[method].apply(obj, [].slice.call(arguments).slice(1))
+  }
+}
+
+exports.map = function (fun) {
+  return function(input) {
+    return input.map(fun)
+  }
+}
+exports.reduce = function(fun) {
+  return function(input) {
+    return input.reduce(fun)
+  }
 }


### PR DESCRIPTION
Add convenience methods:
- bind
- property
- map
- reduce

Now returns from exec() and no longer bugs console.log by default
