### PR TITLE
Remove Scaling from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,6 @@ Furthermore:
 5. Secure sharing, execution, & communications.
 
 ---------------------------------------
-Scaling
----------------------------------------
-
-Filters are pulled from (de)centralized repositories
-and scale should be considered when building and
-deploying private filter repositories.
-
----------------------------------------
 Security
 ---------------------------------------
 


### PR DESCRIPTION
This section needs to be rewritten. Until then, remove it
as not to add confusion.

Signed-off-by: Eric Windisch eric@iopipe.com
