### PR TITLE
Support context callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ translated request or response data.
 Example:
 
 ```javascript
-module.exports = function(input) {
-  return "I'm doing something with input: {0}".format(input)
+module.exports = function(input, context) {
+  context.done("I'm doing something with input: {0}".format(input))
 }
 ```
 

--- a/cli.go
+++ b/cli.go
@@ -192,7 +192,7 @@ func cmdExport(c *cli.Context) {
 		log.Fatal("No pipeline specified for export.")
 	}
 	if name == "" {
-                log.Fatal("Name not specified. Must pass required --name flag.")
+		log.Fatal("Name not specified. Must pass required --name flag.")
 	}
 	exportScript(name, c.Args()...)
 }

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -3,11 +3,13 @@ Future versions of IOpipe may allow kernels to be developed in
 other languages, or to run binary kernels.
 
 A CommonJS module format is employed, expecting a function defined
-as 'module.exports'. This function should return a result intended
-for the next kernel, function, or HTTP endpoint.
+as 'module.exports'. This function should accept two parameters,
+an input variable, and a "context" object providing callbacks.
+The context object has the properties 'succeed', 'done', and 'fail'.
 
-Currently, a single argument and single string-type return variable
-are supported.
+A function should pass its output as intended for the next kernel,
+function, or HTTP endpoint via context.done() or context.succeed()
+callbacks.
 
 ------------------
 Example kernel
@@ -17,11 +19,11 @@ The following converts a JSON document representing a "GenericMessage"
 into a Twitter status update request (as expected by the Twitter API).
 
 ```javascript
-module.exports = function(input) {
+module.exports = function(input, context) {
   var obj = JSON.parse(input)
   var statusRequest = {
     "status": obj["properties"]["text"]
   }
-  return JSON.stringify(statusRequest)
+  context.done(JSON.stringify(statusRequest))
 }
 ```

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -39,11 +39,13 @@ var mypipe = iopipe.define(
   function() {
     return "hello world"
   }
-  ,console.log
+  ,iopipe.callback(console.log)
 )
 
 mypipe()
 ```
+
+Note that all arguments to iopipe.define or iopipe.exec require a callback parameter as its last argument. The method iopipe.callback() is provided as a convenience method to provide a callback to any function that does not, itself, offer a callback parameter.
 
 The *exec* function exists for those not needing a reference to the function:
 
@@ -53,7 +55,7 @@ iopipe.exec(
   function() {
     return "hello world"
   }
-  ,console.log
+  ,iopipe.callback(console.log)
 )
 ```
 
@@ -67,7 +69,7 @@ The following performs an HTTP GET and prints the output to the console:
 
 ```javascript
 var iopipe = require("iopipe")
-iopipe.exec("http://127.0.0.1/my_request/", console.log)
+iopipe.exec("http://127.0.0.1/my_request/", iopipe.callback(console.log))
 ```
 
 Manipulating a response and forwarding it to another server is easily done:
@@ -93,9 +95,9 @@ Modifying the previous example to convert the inline function to a kernel:
 $ # Write a kernel via the shell:
 $ mkdir -p .iopipe/filter_cache/
 $ cat <<EOF >.iopipe/filter_cache/myscript
-module.exports = function(input) {
+module.exports = function(input, context) {
   var x = JSON.decode(input)
-  return x["field"]
+  context.done(x["field"])
 }
 EOF
 ```

--- a/filter_test.go
+++ b/filter_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMakeRunFilter(t *testing.T) {
-	fun, err := makeFilter("module.exports = function(x) { return \"hello\" }")
+	fun, err := makeFilter(`module.exports = function(x, cxt) { cxt.done("hello") }`)
 	if err != nil {
 		t.Error(err)
 	}
@@ -16,7 +16,7 @@ func TestMakeRunFilter(t *testing.T) {
 }
 
 func TestMakeRunEchoFilter(t *testing.T) {
-	fun, err := makeFilter("module.exports = function(input) { return input }")
+	fun, err := makeFilter(`module.exports = function(input, cxt) { cxt.done(input) }`)
 	if err != nil {
 		t.Error(err)
 	}

--- a/js/iopipe.js
+++ b/js/iopipe.js
@@ -375,6 +375,19 @@ exports.fetch = function(u) {
   }
 }
 
+
+/**
+  Creates a new function accepting a callback around a function
+  which does not accept a callback parameter as its last argument.
+
+  @param {...function} function - Function to wrap a callback around.
+*/
+exports.callback = function(fun) {
+  return function(input, done) {
+    done(fun(input))
+  }
+}
+
 /**
    We monkey-patch the Object.values function,
    this makes it easier to map assoc arrays using tee.

--- a/spec/iopipe_spec.js
+++ b/spec/iopipe_spec.js
@@ -9,91 +9,108 @@ describe("define", function() {
 
 describe("defined-function", function() {
   it("can pass no args", function(done) {
-    var fun = iopipe.define(function(i) {
+    var fun = iopipe.define(function(i, cb) {
       expect(i).toEqual(undefined)
+      cb()
       done()
     })
     fun()
   })
   it("can pass one arg", function(done) {
     var expected = "hello world"
-    var fun = iopipe.define(function(i) {
-      expect(i).toEqual(expected)
+    var fun = iopipe.define(function(i, cb) {
+      expect(i).toEqual(expected); cb()
     }, done)
     fun(expected)
   })
-  /* depends on upcoming context patch *
   it("can trigger callback", function(done) {
-    var fun = iopipe.define(function() { })
+    var fun = iopipe.define(function(_, cb) { cb() })
     fun("", done)
   })
   it("passes result to callback", function(done) {
     var input = 2
     var expected = 3
-    var fun = iopipe.define(function(i) {
-      return i + 1
+    var fun = iopipe.define(function(i, cb) {
+      cb(i + 1)
     })
     fun(input, function(i) { 
       expect(i).toEqual(expected)
       done()
     })
   })
-  */
 })
 
 describe("map", function() {
-  it("has as many outputs as inputs", function() {
+  it("has as many outputs as inputs", function(done) {
     var input = [0, 1, 2]
-    var output = iopipe.map(function(i) { return i + 2 })(input)
-    expect(input.length).toEqual(output.length);
+    iopipe.map(function(i, cb) { cb(i + 2) })(input, function(output) {
+      expect(input.length).toEqual(output.length);
+      done()
+    })
   });
-  it("preserves order", function() {
+  it("preserves order", function(done) {
     var input = [0, 1, 2]
-    var output = iopipe.map(function(i) { return i })(input)
-    expect(output).toEqual(input);
+    iopipe.map(function(i, cb) { cb(i) })(input, function(output) {
+      expect(output).toEqual(input);
+      done()
+    })
   });
-  it("transforms each input element", function() {
+  it("transforms each input element", function(done) {
     var input = [0, 1, 2]
     var expected = [1, 2, 3]
-    var output = iopipe.map(function(i) { return i + 1 })(input)
-    expect(output).toEqual(expected)
+    iopipe.map(function(i, cb) { cb(i + 1) })(input, function(output) {
+      expect(output).toEqual(expected)
+      done()
+    })
   });
 });
 
 describe("tee", function() {
-  it("has as many outputs as functions", function() {
+  it("has as many outputs as functions", function(done) {
     var input = [0, 1, 2, 3, 4]
-    var echo = function(i) { return i }
-    var output = iopipe.tee(echo, echo)(input)
-    expect(output.length).toEqual(2);
+    var echo = function(i, cb) { cb(i) }
+    iopipe.tee(echo, echo)(input, function(output) {
+      expect(output.length).toEqual(2);
+      done()
+    })
   });
-  it("preserves order", function() {
+  it("preserves order", function(done) {
     var input = [0, 1, 2]
-    var echo = function(i) { return i }
-    var ret2 = function(i) { return 2 }
-    var output = iopipe.tee(echo, ret2)(input)
-    expect(output).toEqual([ echo(input), ret2(input) ]);
+    var echo = function(i, cb) { cb(i) }
+    var ret2 = function(i, cb) { cb(2) }
+    iopipe.tee(echo, ret2)(input, function(output) {
+      echo(input, function(e) {
+        ret2(input, function(r) {
+          expect(output).toEqual([e, r])
+          done()
+        })
+      })
+    })
   });
 });
 
 describe("reduce", function() {
-  it("can sum all input elements", function() {
+  it("can sum all input elements", function(done) {
     var input = [1, 2, 3]
     var sum = function(prev, next) {
       return prev + next
     }
-    var output = iopipe.reduce(sum)(input)
-    expect(output).toEqual(6)
+    iopipe.reduce(sum)(input, function(output) {
+      expect(output).toEqual(6)
+      done()
+    })
   });
 })
 
 describe("exec", function() {
   it("can chain functions", function(done) {
-    iopipe.exec(function() { return "hello world" }
-                ,function(input) {
+    iopipe.exec(function(_, cb) { cb("hello world") }
+                ,function(input, cb) {
                   expect(input).toEqual("hello world")
+                  done()
+                  cb()
                 }
-                ,done)
+                ,function(input, cb) { done(); cb() })
   });
 })
 
@@ -104,9 +121,11 @@ describe("apply", function() {
 })
 
 describe("property", function() {
-  it("returns property for arg", function() {
+  it("returns property for arg", function(done) {
     var obj = { "key": "hello world" }
-    var output = iopipe.property("key")(obj)
-    expect(output).toEqual(obj["key"])
+    iopipe.property("key")(obj, function (output) {
+      expect(output).toEqual(obj["key"])
+      done()
+    })
   });
 })

--- a/spec/iopipe_spec.js
+++ b/spec/iopipe_spec.js
@@ -129,3 +129,15 @@ describe("property", function() {
     })
   });
 })
+
+describe("callback", function() {
+  it("calls function", function(done) {
+    iopipe.callback(done)()
+  })
+  it("passes input to function", function(done) {
+    iopipe.callback(function(input) {
+      expect(input).toEqual("hello world")
+      done()
+    })("hello world")
+  })
+})


### PR DESCRIPTION
Passes a context variable to kernels, making it necessary for kernels
to execute a context.done() or context.fail() upon completion.

This also means that functions passed in a waterfall/flow must also
expect a callback. This makes the code more Node-friendly in some ways.

The map and tee functions are now asynchronous as well, using
event emitters and a collector to retrieve results.

Signed-off-by: Eric Windisch eric@iopipe.com
