### PR TITLE
Fix/support callback for define()

### DIFF
--- a/spec/iopipe_spec.js
+++ b/spec/iopipe_spec.js
@@ -41,11 +41,16 @@ describe("defined-function", function() {
   })
   it("passes result to callback", function(done) {
     var input = 2
-    var expected = 3
-    var fun = iopipe.define(function(i, ctx) {
-      ctx.done(i + 1)
-    })
-    fun(input, function(i) { 
+    var expected = 4
+    var fun = iopipe.define(
+      function(i, ctx) {
+        ctx(i + 1)
+      },
+      function(i, ctx) {
+        ctx(i + 1)
+      }
+    )
+    fun(input, function(i) {
       expect(i).toEqual(expected)
       done()
     })


### PR DESCRIPTION
The define() function returns a function which has supported
an input parameter and was supposed to support a callback. The
callback mechanism was not working correctly and was only
running define's first function, so now it's fixed.

The test has been adapted to ensure that multiple functions
are chained before verifying that the callback succeeds.

Signed-off-by: Eric Windisch eric@windisch.us
