### PR TITLE
Bump ver 0.0.7; serverless/lambda keywords for npm

### DIFF
--- a/js/iopipe.js
+++ b/js/iopipe.js
@@ -35,7 +35,7 @@ var path = require('path')
 
 var local_driver = require('./exec_drivers/local/index.js')
 
-var USERAGENT = "iopipe/0.0.6"
+var USERAGENT = "iopipe/0.0.7"
 
 /**
    @description

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iopipe",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "iopipe sdk",
   "author": "Eric Windisch",
   "files": [
@@ -12,7 +12,9 @@
     "flow",
     "waterfall",
     "async",
-    "functional"
+    "functional",
+    "serverless",
+    "aws-lambda"
   ],
   "dependencies": {
     "aws-sdk": "",


### PR DESCRIPTION
Bumps 0.0.7 and adds npm keyboards.
